### PR TITLE
Update useconstraints.asciidoc

### DIFF
--- a/docs/partials/useconstraints.asciidoc
+++ b/docs/partials/useconstraints.asciidoc
@@ -42,7 +42,7 @@ can have open access (e.g. to look at it), but restricted use.
 |Revision date |September 2018
 |===
 
-Corresponding element in other standards...
+.Corresponding element in other standards...
 [%collapsible]
 ====
 |===


### PR DESCRIPTION
Make the "Corresponding element in other standards" directly collapsible, as in the other elements (without the leading dot, we get an extra "details" heading as the actually collapsible part)