### PR TITLE
Update useconstraints.asciidoc

### DIFF
--- a/docs/partials/useconstraints.asciidoc
+++ b/docs/partials/useconstraints.asciidoc
@@ -99,8 +99,6 @@ shown in Example Two may be used. This is recommended for licenses, even
 the use of ISO 19115 otherRestrictions would not generally include
 license restrictions, as they have their own term in the ISO 19115 code
 list.
-. If there are no limitations the value of gmd:otherConstraints shall be
-'no limitations' (see Example Three).
 . There may be more than one gmd:otherConstraints element
 |Example One
 |


### PR DESCRIPTION
Remove encoding guidance point 8, which contradicted Guidance point 2 & the example that illustrates it. (Probably a copy/paste error from Limitations on public access)